### PR TITLE
Allow modification of 'incomplete-dir' location

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,2 +1,3 @@
 Vyacheslav Levit <dev@vlevit.org>
 Jure Vengušt <jure.vengust@gmail.com>
+Artem Mygaiev <joculator@gmail.com>

--- a/README.md
+++ b/README.md
@@ -10,19 +10,21 @@ Usage
     transmission-batch-move [OPTIONS] PATTERN REPLACEMENT
 
 The script will search PATTERN (regex) and replace it with REPLACEMENT
-in all destination properties of Transmission resume files in
-`~/.config/transmission/resume` directory. It will recalculate lengths
-of new destination paths, so resume files should not break. All
-original resume files are backed up. To be on the safe side make a
-backup before running the script yourself.
+in all destination or incomplete-dir properties of Transmission resume
+files in `~/.config/transmission/resume` directory. It will recalculate
+lengths of new paths, so resume files should not break. All original
+resume files are backed up. To be on the safe side make a backup before
+running the script yourself.
 
 Options
 =======
 
-     -h, --help    Displays this help.
-     -y, --yes     Ignore safety prompt.
-     --path=PATH   Specify configuration directory where resume folder
-                   is located. Default is "~/.config/transmission"
+ -h, --help           Displays this help.
+ -y, --yes            Ignore safety prompt.
+ -d, --destination    Change destination location.
+ -i, --incomplete-dir Change incomplete directory location.
+ --path=PATH          Specify configuration folder where resume directory
+                      is located. Default is "~/.config/transmission"
 
 Transmission daemon on Debian / Ubuntu
 ======================================
@@ -31,4 +33,4 @@ For Debian and derivative distributions Transmission daemon
 configuration directory is set to `/var/lib/transmission-daemon/info`
 by default. So pass `--path` as follows:
 
-    transmission-batch-move --path=/var/lib/transmission-daemon/info PATTERN REPLACEMENT
+    transmission-batch-move --path=/var/lib/transmission-daemon/info -i PATTERN REPLACEMENT

--- a/transmission-batch-move
+++ b/transmission-batch-move
@@ -15,11 +15,16 @@ Usage: ${0##*/} [OPTIONS] PATTERN REPLACEMENT
 Change all torrents location. Do NOT move actual downloaded files,
 just change their location in *.resume files.
 
+It is mandatory to specify which location must be changed - either
+'destination' or 'incomplete-dir'.
+
 Options:
- -h, --help    Displays this help.
- -y, --yes     Ignore safety prompt.
- --path=PATH   Specify configuration folder where resume directory
-               is located. Default is "$CONFIG"
+ -h, --help           Displays this help.
+ -y, --yes            Ignore safety prompt.
+ -d, --destination    Change destination location.
+ -i, --incomplete-dir Change incomplete directory location.
+ --path=PATH          Specify configuration folder where resume directory
+                      is located. Default is "$CONFIG"
 EOF
 }
 
@@ -39,6 +44,16 @@ case $i in
     REPLY=y
     shift
     ;;
+    -d|--download-dir)
+    OFFSET=14
+    TOKEN="11:destination"
+    shift
+    ;;
+    -i|--incomplete-dir)
+    OFFSET=17
+    TOKEN="14:incomplete-dir"
+    shift
+    ;;
     *)
     # ignore positional arguments
     ;;
@@ -49,6 +64,11 @@ RESUME="${CONFIG}/resume"
 ORIG="${CONFIG}/resume-$(date +%Y%m%d-%H%M%S)"
 
 if (( $# != 2 )); then
+    help
+    exit 2
+fi
+
+if [ -z $OFFSET ]; then
     help
     exit 2
 fi
@@ -66,6 +86,7 @@ fi
 echo "Transimission configuration folder: $CONFIG"
 echo "Resume files folder: $RESUME"
 echo "Backup folder: $ORIG"
+echo "Changing: $TOKEN"
 echo "PATTERN: $1"
 echo "REPLACEMENT: $2"
 
@@ -95,10 +116,10 @@ do
     echo "processing $(basename "$file")"
 
     # calculate destination position
-    dest=$(grep -aob "11:destination[0-9]\+" "$file")
+    dest=$(grep -aob "$TOKEN[0-9]\+" "$file")
     old_len=$(grep -o "[0-9]\+$" <<< "$dest")
     pos=$(grep -o "^[0-9]\+" <<< "$dest")
-    end=$(($pos+14+${#old_len}+1+$old_len))
+    end=$(($pos+$OFFSET+${#old_len}+1+$old_len))
 
     # fetch the destination path, make the substitution
     old_path="$(head -c $end "$file"| tail -c $old_len)"
@@ -111,7 +132,7 @@ do
 
     # new path length in bytes, not characters
     new_len=$(echo -n "$new_path" | wc -c)
-    new_dest="11:destination${new_len}:${new_path}"
+    new_dest="$TOKEN${new_len}:${new_path}"
 
     # write temporary file and replace the original one
     tmpfile="${file}.tmp.$$"


### PR DESCRIPTION
Sometimes it is necessary to change not only location of 'destination'
but also location of 'incomplete-dir' where temporary downloads are
stored as configured by Transmissions 'resume' files.

Added 2 options:
  -d or --destination to change torrent's destination location
  -i or --incomplete-dir to change torrents incomplete location
Now it is mandantory to specify one of them when running the script.
The logic was tested and checked with shellcheck.

README and AUTHORS are updated accordingly.