### PR TITLE
Bug Fix: tail error message

### DIFF
--- a/transmission-batch-move
+++ b/transmission-batch-move
@@ -106,7 +106,7 @@ do
     end=$(($pos+14+${#old_len}+1+$old_len))
 
     # fetch the destination path, make the substitution
-    old_path="$(head -c $end "$file"| tail -c $old_len)"
+    old_path="$(head -c $end "$file"| tail -c -$old_len)"
     new_path="$(sed -e "s,${PATTERN},${REPLACEMENT}," <<< "$old_path")"
 
     if test "$old_path" = "$new_path"; then


### PR DESCRIPTION
On some systems tail reads $old_len as the filename. By adding a - in front of $old_len, it reads it properly and the script no longer breaks.

Issue #8 relates to the error message this fixes.